### PR TITLE
normalization option for prediction data

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -70,6 +70,7 @@ Notes:
 | name                  | string  | Yes       | n/a     |                                                                                          |
 | preloaded             | string  | Yes       | n/a     |                                                                                          |
 | interpolation_method  | integer | No        | 1       | nearest neighbor= 1, bilenear =2                                                         |
+| normalization_method  | integer | No        | 0       | mean/stddev from: prediction data = 0, training data = 1                                 |
 | nvars                 | integer | Yes       | -1      |                                                                                          |
 | data_type             | string  | Yes       | n/a     |                                                                                          |
 | lat_name              | string  | Yes       | n/a     |                                                                                          |

--- a/src/config/configuration.f90
+++ b/src/config/configuration.f90
@@ -323,7 +323,7 @@ contains
         integer :: name_unit, i, j
 
         ! namelist variables to be read
-        integer :: nfiles, nvars, calendar_start_year, selected_time, interpolation_method
+        integer :: nfiles, nvars, calendar_start_year, selected_time, interpolation_method, normalization_method
         double precision :: timezone_offset
         integer, dimension(MAX_NUMBER_TIMES) :: time_indices
         integer, dimension(MAX_NUMBER_VARS) :: selected_level
@@ -343,7 +343,7 @@ contains
                                          input_transformations, transformations,&
                                          interpolation_method, preloaded,   &
                                          selected_level, time_indices, &
-                                         timezone_offset
+                                         timezone_offset, normalization_method
 
         !defaults :
         nfiles              = -1
@@ -361,6 +361,7 @@ contains
         transformations     = kNO_TRANSFORM
         input_transformations = kNO_TRANSFORM
         interpolation_method = kNEAREST
+        normalization_method = kPREDICTIONDATA
         preloaded           = ""
         time_indices        = -1
         selected_level      = -1
@@ -405,6 +406,7 @@ contains
         prediction_options%transformations= transformations
         prediction_options%input_Xforms   = input_transformations(1:nvars)
         prediction_options%interpolation_method = interpolation_method
+        prediction_options%normalization_method = normalization_method
         prediction_options%debug          = debug
         prediction_options%preloaded      = preloaded
 

--- a/src/downscaling_stats/downscaling.f90
+++ b/src/downscaling_stats/downscaling.f90
@@ -155,7 +155,11 @@ contains
 
                     ! does not need to be normalized if it will be transformed to match training_atm anyway
                     if (abs(options%prediction%transformations(v)) /= kQUANTILE_MAPPING) then
-                        call normalize(predictors%variables(v), j)
+                        if (options%prediction%normalization_method == kTRAININGDATA) then
+                            call normalize(predictors%variables(v), j, other=training_atm%variables(v))
+                        else
+                            call normalize(predictors%variables(v), j)
+                        endif
                     endif
                 enddo
                 !$omp end do
@@ -812,19 +816,27 @@ contains
     ! normalize an atmospheric variable by subtracting the mean and dividing by the standard deviation
     ! Assumes mean and stddev have already been calculated as part of the data structure
     ! If stddev is 0, then no division occurs (mean is still removed)
-    subroutine normalize(var, j)
+    subroutine normalize(var, j, other)
         implicit none
-        class(atm_variable_type), intent(inout) :: var
+        class(atm_variable_type), target, intent(inout) :: var
         integer, intent(in)                     :: j
+        class(atm_variable_type), intent(in), target, optional :: other
         integer :: i, n
+        class(atm_variable_type), pointer :: norm_data
 
         n = size(var%mean,1)
 
+        if (present(other)) then
+            norm_data => other
+        else
+            norm_data => var
+        endif
+
         do i=1,n
-            var%data(:,i,j) = var%data(:,i,j) - var%mean(i,j)
+            var%data(:,i,j) = var%data(:,i,j) - norm_data%mean(i,j)
 
             if (var%stddev(i,j) /= 0) then
-                var%data(:,i,j) = var%data(:,i,j) / var%stddev(i,j)
+                var%data(:,i,j) = var%data(:,i,j) / norm_data%stddev(i,j)
             else
                 if (maxval(abs(var%data(:,i,j))) > 0) then
                     !$omp critical (print_lock)
@@ -835,7 +847,7 @@ contains
                 endif
             endif
             ! shift to a 0-based range so that variables such as precip have a testable non-value
-            var%data(:,i,j) = var%data(:,i,j) - minval(var%data(:,i,j))
+            var%data(:,i,j) = var%data(:,i,j) - minval(norm_data%data(:,i,j))
             where(abs(var%data(:,i,j)) < 1e-10) var%data(:,i,j)=0
         enddo
 

--- a/src/objects/data_structures.f90
+++ b/src/objects/data_structures.f90
@@ -176,8 +176,9 @@ module data_structures
         ! tranformation to apply to each atmophseric variable
         integer, dimension(:), allocatable :: transformations
     end type atm_config
-
     type, extends(atm_config) :: prediction_config
+        ! source of data to use for normalization of prediction data
+        integer :: normalization_method
     end type prediction_config
 
     type, extends(atm_config) :: training_config

--- a/src/objects/model_constants.f90
+++ b/src/objects/model_constants.f90
@@ -48,6 +48,12 @@ module model_constants
     integer,public,parameter :: kBILINEAR         = 2
 
     ! ------------------------------------------------
+    ! Normalization Method
+    ! ------------------------------------------------
+    integer,public,parameter :: kPREDICTIONDATA   = 1
+    integer,public,parameter :: kTRAININGDATA     = 2
+
+    ! ------------------------------------------------
     ! Other Constants
     ! ------------------------------------------------
     integer,public,parameter :: kFILL_VALUE       = -9999


### PR DESCRIPTION
This PR adds the logic to allow for using the training data mean/stddev for normalization of the prediction data.  This is particularly useful when the prediction data is only one timestep.

cc @gutmann for initial review