### PR TITLE
Various minor fixes and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ test_regression
 test_calendar
 test_qm
 test_config
-downscale
+gard

--- a/run/downscale_options.txt
+++ b/run/downscale_options.txt
@@ -4,7 +4,7 @@
     ! observation_file    = "downscale_options.nml"
     ! prediction_file     = "downscale_options.nml"
 
-    output_file     = "log_reg_output/"
+    output_file     = "output/gard_out_"        ! prefix for output files
 
     start_date       = "2000-01-01 00:00:00"    ! start time for the output data (only needs to exist in the prediction dataset)
     end_date         = "2000-01-31 23:00:00"    ! end time for the output data
@@ -16,14 +16,14 @@
     end_transform    = "1999-01-01 23:00:00"    ! end time for the transformation period
 
     ! model types
-    pure_regression   = False       ! set to true (and others to false) to compute a single regression (no analogs) between training variables and observations to be applied to all predictor data
-    pure_analog       = False       ! set to true (and others to false) to use the selected analogs (no regression) to predict the output
-    analog_regression = True        ! set to true (and others to false) to perform a regression only on the selected analog days when predicting the output
+    pure_regression   = False                   ! set to true (and others to false) to compute a single regression (no analogs) between training variables and observations to be applied to all predictor data
+    pure_analog       = False                   ! set to true (and others to false) to use the selected analogs (no regression) to predict the output
+    analog_regression = True                    ! set to true (and others to false) to perform a regression only on the selected analog days when predicting the output
 
     ! analog selection parameters
-    n_analogs       = 200           ! set the number of analogs to find for each time step
-    ! n_log_analogs   = 20          ! set to the number of analogs to use for the logistic_from_analog_exceedance calculation if using something other than n_analogs
-    ! analog_threshold  = 0.25      ! set to use a threshold distance when selecting analogs instead of a fixed number (in units of standard deviations averaged across input variables)
+    n_analogs           = 200                   ! set the number of analogs to find for each time step
+    ! n_log_analogs     = 20                    ! set to the number of analogs to use for the logistic_from_analog_exceedance calculation if using something other than n_analogs
+    ! analog_threshold  = 0.25                  ! set to use a threshold distance when selecting analogs instead of a fixed number (in units of standard deviations averaged across input variables)
 
     ! model options
     sample_analog = False                       ! when using pure_analog this will sample randomly from the selection of analogs instead of using the mean
@@ -45,6 +45,9 @@
     lon_name  = "XLONG"                 ! name of a variable in the input data that contains the longitude of each grid cell (can be a 1D or 2D variable)
     time_name = "XTIME"                 ! name of a variable in the input data that contains the time data (must be a number ideally with a units attribute such as "days since YYYY-MM-DD hh:mm:ss")
     nfiles    = 21                      ! the number of files to be read
+    selected_level = -1                 ! If the input data have 4 dimensions (e.g. one dimension is elevation) this is the index that will be used
+                                        ! this assumes that the z dimension is the 2nd (time, z, y, x) in the NetCDF file
+                                        ! if -1, the first level will be used.
 
     ! the following are arrays with one element for each input variable
     input_transformations = 0, 0, 3, 3  ! transformations to apply to each input variable (0=none, 1=qm?, 2=log, 3=cuberoot, 4=fifthroot)
@@ -55,6 +58,13 @@
 
     ! calendar to be used when interpreting the time variable, "gregorian", "standard", "noleap", "365-day","360-day" all work
     calendar  = "gregorian"
+    calendar_start_year = 1900          ! set this to the year the time data use as time 0, will be read from the NetCDF units attribute if possible
+    timezone_offset = 0                 ! offset (in hours) to add to the time data to permit a better match with the local obs. data
+
+    ! the following options are primarily for forecasting
+    ! GEFS data have n time-steps per file, corresponding to the n-forecast lead times
+    selected_time = -1                  ! if set, only this time step will be read from each input file
+    time_indices = -1, -1, -1           ! this can be a list of time steps to read and average over instead
 /
 
 ! Define the input atmospheric model data to be used when applying the model for future predictions
@@ -72,13 +82,23 @@
 
     input_transformations = 0, 0, 3, 3
 
-    ! this is the main difference between training and prediction data, permits an additional transformation to e.g. quantile map (transformation=1) each variable to match the training data
+    ! Here is the main difference between training and prediction data
+    ! This permits an additional transformation to e.g. quantile map (transformation=1) each variable to match the training data
+    ! this is primarily for climate simulations
     transformations = 0, 0, 0, 0
+    ! Also, if normalization_method = 1, the means and standard deviations from the training data will be used to normalize the predictors
+    ! this is primarily for forecasting applications
+    normalization_method = 0
 
     var_names = "T2",                            "PSFC",                          "PREC_ACC_NC",                   "PREC_ACC_C"
     file_list = "filelists/erai_files_200x.txt", "filelists/erai_files_200x.txt", "filelists/erai_files_200x.txt", "filelists/erai_files_200x.txt"
 
     calendar  = "gregorian"
+    calendar_start_year = 1900
+    timezone_offset = 0
+
+    selected_time = -1
+    time_indices = -1, -1, -1
 /
 
 ! Define the input observation data to be used when training the model
@@ -99,4 +119,10 @@
     file_list = "filelists/obs_files_complete.txt"
 
     calendar  = "gregorian"
+    calendar_start_year = 1900
+
+    ! specify a variable to use to find which grid cells should be masked
+    mask_variable = 1
+    ! specify a value to use to in that variable to define masked gridcells
+    mask_value = 1e20
 /

--- a/src/config/configuration.f90
+++ b/src/config/configuration.f90
@@ -89,7 +89,7 @@ contains
         end_train        = ""
         start_transform  = ""
         end_transform    = ""
-        output_file      = "downscaled_output.nc"
+        output_file      = "gard_out_"
         n_analogs        = -1
         n_log_analogs    = -1
         analog_threshold = -1
@@ -365,6 +365,7 @@ contains
         preloaded           = ""
         time_indices        = -1
         selected_level      = -1
+        timezone_offset     = 0
 
         ! read namelists
         open(io_newunit(name_unit), file=filename)
@@ -409,6 +410,7 @@ contains
         prediction_options%normalization_method = normalization_method
         prediction_options%debug          = debug
         prediction_options%preloaded      = preloaded
+        prediction_options%timezone_offset= timezone_offset
 
         where(prediction_options%selected_level == -1) prediction_options%selected_level = 1
         call check_prediction_options(prediction_options)

--- a/src/downscaling_stats/downscaling.f90
+++ b/src/downscaling_stats/downscaling.f90
@@ -623,7 +623,11 @@ contains
                     timers(2) = timers(2) + (timetwo-timeone)
                     ! revert to a pure analog approach.  By passing analogs and weights, it will not recompute which analogs to use
                     ! it will just compute the analog mean, pop, and error statistics
-                    call downscale_pure_analog(x, atm, obs, output_coeff, output, error, logistic, options, timers, analogs, weights)
+                    if (present(cur_time)) then
+                        call downscale_pure_analog(x, atm, obs, output_coeff, output, error, logistic, options, timers, analogs, weights, cur_time)
+                    else
+                        call downscale_pure_analog(x, atm, obs, output_coeff, output, error, logistic, options, timers, analogs, weights)
+                    endif
                     coefficients(1:nvars) = output_coeff(1:nvars)
                     coefficients(1) = 1e20
                     call System_Clock(timeone)

--- a/src/io/gefs_io.f90
+++ b/src/io/gefs_io.f90
@@ -83,7 +83,7 @@ contains
 
         allocate(GEFS_data%times(ntimesteps))
         if (debug) write(*,*) "Reading Time data"
-        call read_times(options, GEFS_data%times)
+        call read_times(options, GEFS_data%times, options%timezone_offset)
         if (debug) then
             write(*,*) "Times cover the period:"
             write(*,*) "   "//trim(GEFS_data%times(1)%as_string())


### PR DESCRIPTION
UPDATED documentation for the sample options file

ADDED timezone_offset both to predictor namelist and made it used in GEFS_io

BUGFIX in analog regression that would let the fallback pure_analog mode use the current timestep as a possible analog

Changed .gitignore to stop reporting on the gard binary