### PR TITLE
improved minval handling for normalization

### DIFF
--- a/src/downscaling_stats/downscaling.f90
+++ b/src/downscaling_stats/downscaling.f90
@@ -853,7 +853,9 @@ contains
                 endif
             endif
             ! shift to a 0-based range so that variables such as precip have a testable non-value
-            var%data(:,i,j) = var%data(:,i,j) - minval(norm_data%data(:,i,j))
+            var%min_val(i,j) = minval(var%data(:,i,j))
+
+            var%data(:,i,j) = var%data(:,i,j) - norm_data%min_val(i,j)
             where(abs(var%data(:,i,j)) < 1e-10) var%data(:,i,j)=0
         enddo
 
@@ -873,6 +875,7 @@ contains
         do i=1,nx
             input_var%mean(i,j) = sum(input_var%data(:,i,j)) / ntimes
             input_var%stddev(i,j) = stddev(input_var%data(:,i,j), input_var%mean(i,j))
+            input_var%min_val(i,j) = minval(input_var%data(:,i,j))
         enddo
 
     end subroutine update_statistics

--- a/src/io/gcm_io.f90
+++ b/src/io/gcm_io.f90
@@ -12,7 +12,7 @@ module gcm_mod
 
     use data_structures
     use model_constants
-    use basic_stats_mod,only: time_mean, time_stddev
+    use basic_stats_mod,only: time_mean, time_stddev, time_minval
     use string,         only: str
     use io_routines,    only: io_read, io_getdims, io_maxDims
     use time_io,        only: read_times
@@ -98,13 +98,16 @@ contains
 
         if (allocated(var%mean))    deallocate(var%mean)
         if (allocated(var%stddev))  deallocate(var%stddev)
+        if (allocated(var%min_val))  deallocate(var%min_val)
         allocate(var%mean(nx,ny))
         allocate(var%stddev(nx,ny))
+        allocate(var%min_val(nx,ny))
 
         where(var%data>1e10) var%data=0
 
         call time_mean( var%data, var%mean )
         call time_stddev( var%data, var%stddev, mean_in=var%mean )
+        call time_minval( var%data, var%min_val)
 
     end subroutine compute_grid_stats
 

--- a/src/io/gefs_io.f90
+++ b/src/io/gefs_io.f90
@@ -12,7 +12,7 @@ module gefs_mod
 
     use data_structures
     use model_constants
-    use basic_stats_mod,only: time_mean, time_stddev
+    use basic_stats_mod,only: time_mean, time_stddev, time_minval
     use string,         only: str
     use io_routines,    only: io_read, io_getdims, io_maxDims, file_exists
     use time_io,        only: read_times
@@ -109,13 +109,16 @@ contains
 
         if (allocated(var%mean))    deallocate(var%mean)
         if (allocated(var%stddev))  deallocate(var%stddev)
+        if (allocated(var%min_val))  deallocate(var%min_val)
         allocate(var%mean(nx,ny))
         allocate(var%stddev(nx,ny))
+        allocate(var%min_val(nx,ny))
 
         where(var%data>1e10) var%data=0
 
         call time_mean( var%data, var%mean )
         call time_stddev( var%data, var%stddev, mean_in=var%mean )
+        call time_minval( var%data, var%min_val)
 
     end subroutine compute_grid_stats
 

--- a/src/io/obs_io.f90
+++ b/src/io/obs_io.f90
@@ -12,7 +12,7 @@ module obs_mod
 
     use data_structures
     use model_constants
-    use basic_stats_mod,only: time_mean, time_stddev
+    use basic_stats_mod,only: time_mean, time_stddev, time_minval
     use string,         only: str
     use io_routines,    only: io_read, io_getdims, io_maxDims
     use time_io,        only: read_times
@@ -126,13 +126,16 @@ contains
 
         if (allocated(var%mean))    deallocate(var%mean)
         if (allocated(var%stddev))  deallocate(var%stddev)
+        if (allocated(var%min_val))  deallocate(var%min_val)
         allocate(var%mean(nx,ny))
         allocate(var%stddev(nx,ny))
+        allocate(var%min_val(nx,ny))
 
-        ! where(var%data>1e30) var%data=0
+        where(var%data>1e10) var%data=0
 
         call time_mean( var%data, var%mean )
         call time_stddev( var%data, var%stddev, mean_in=var%mean )
+        call time_minval( var%data, var%min_val)
 
     end subroutine compute_grid_stats
 

--- a/src/objects/data_structures.f90
+++ b/src/objects/data_structures.f90
@@ -78,7 +78,7 @@ module data_structures
         character(len=MAXVARLENGTH), allocatable, dimension(:) :: attributes_names
         character(len=MAXVARLENGTH), allocatable, dimension(:) :: attributes_values
 
-        real, allocatable, dimension(:,:) :: mean, stddev ! per gridpoint mean and standard deviation (for normalization)
+        real, allocatable, dimension(:,:) :: min_val, mean, stddev ! per gridpoint mean and standard deviation (for normalization)
     end type variable_type
 
     ! ------------------------------------------------

--- a/src/utilities/basic_stats.f90
+++ b/src/utilities/basic_stats.f90
@@ -4,6 +4,34 @@ module basic_stats_mod
     
 contains
     
+    
+    !>-------------------------------------
+    !! Compute the minval over the first dimension
+    !!
+    !! precondition: nt>0
+    !!
+    !!-------------------------------------
+    subroutine time_minval(input, min_val)
+        implicit none
+        real, intent(in),   dimension(:,:,:) :: input
+        real, intent(inout),dimension(:,:)   :: min_val
+        
+        integer :: nx, ny, nt
+        integer :: x, y
+        
+        nt = size(input,1)
+        nx = size(input,2)
+        ny = size(input,3)
+        
+        do y=1,ny
+            do x=1,nx
+                min_val(x,y) = minval(input(:,x,y))
+            end do
+        end do
+        
+    end subroutine time_minval
+
+
     !>-------------------------------------
     !! Compute the mean over the first dimension
     !!


### PR DESCRIPTION
There was an issue related to normalizing the predictor data based on the training data

Most steps in that normalization step use pre-calculated values, so it wasn’t a problem
but there is a last step where the minimum value in the dataset is subtracted
(to get rid of negative values in case one wanted to take a sqrt)
That step uses the minimum value of the normalization data.

Now a minval field is added to the variable datatype, allocated and initialized
in the IO code, and updated in the normalization code after removing mean and stddev
but before removing the minval itself.