### PR TITLE
Feature/coefficient io

### DIFF
--- a/src/config/configuration.f90
+++ b/src/config/configuration.f90
@@ -64,7 +64,7 @@ contains
         logical :: pure_analog, analog_regression, pure_regression, pass_through, debug, interactive
         logical :: sample_analog, logistic_from_analog_exceedance, weight_analogs
         logical :: read_coefficients, write_coefficients
-        character(len=MAXFILELENGTH)    :: coefficients_file
+        character(len=MAXFILELENGTH)    :: coefficients_files(MAX_NUMBER_VARS)
         real    :: logistic_threshold, analog_threshold
 
         ! setup the namelist
@@ -79,7 +79,7 @@ contains
                                 analog_threshold, weight_analogs,                   &
                                 pass_through, pass_through_var,                     &
                                 read_coefficients, write_coefficients,              &
-                                coefficients_file
+                                coefficients_files
 
         options%version = kVERSION_STRING
         options%options_filename = get_options_file()
@@ -111,7 +111,7 @@ contains
         weight_analogs   = .True.
         read_coefficients= .False.
         write_coefficients=.False.
-        coefficients_file= ""
+        coefficients_files= ""
 
         options%name = options%options_filename
 
@@ -163,7 +163,7 @@ contains
         
         options%read_coefficients  = read_coefficients
         options%write_coefficients = write_coefficients
-        options%coefficients_file  = coefficients_file
+        options%coefficients_files = coefficients_files
     end subroutine read_base_options
 
 

--- a/src/config/configuration.f90
+++ b/src/config/configuration.f90
@@ -63,6 +63,8 @@ contains
         character(len=MAXFILELENGTH)    :: training_file, prediction_file, observation_file, output_file
         logical :: pure_analog, analog_regression, pure_regression, pass_through, debug, interactive
         logical :: sample_analog, logistic_from_analog_exceedance, weight_analogs
+        logical :: read_coefficients, write_coefficients
+        character(len=MAXFILELENGTH)    :: coefficients_file
         real    :: logistic_threshold, analog_threshold
 
         ! setup the namelist
@@ -75,7 +77,9 @@ contains
                                 pure_analog, analog_regression, pure_regression,    &
                                 sample_analog, logistic_from_analog_exceedance,     &
                                 analog_threshold, weight_analogs,                   &
-                                pass_through, pass_through_var
+                                pass_through, pass_through_var,                     &
+                                read_coefficients, write_coefficients,              &
+                                coefficients_file
 
         options%version = kVERSION_STRING
         options%options_filename = get_options_file()
@@ -105,6 +109,9 @@ contains
         sample_analog    = .False.
         logistic_from_analog_exceedance = .False.
         weight_analogs   = .True.
+        read_coefficients= .False.
+        write_coefficients=.False.
+        coefficients_file= ""
 
         options%name = options%options_filename
 
@@ -153,7 +160,10 @@ contains
         options%debug = debug
         options%interactive = interactive
         module_debug = options%debug
-
+        
+        options%read_coefficients  = read_coefficients
+        options%write_coefficients = write_coefficients
+        options%coefficients_file  = coefficients_file
     end subroutine read_base_options
 
 

--- a/src/downscaling_stats/downscaling.f90
+++ b/src/downscaling_stats/downscaling.f90
@@ -499,7 +499,10 @@ contains
             timers(3) = timers(3) + (timetwo-timeone)
         
         elseif (options%pure_regression .and. options%read_coefficients) then
-            coefficients_r4 = output_coeff(:,1)
+            coefficients_r4(1:nvars) = output_coeff(1:nvars,1)
+            if (logistic_threshold/=kFILL_VALUE) then
+                coefficients_r4(nvars+1:nvars*2) = output_coeff(nvars+1:nvars*2,1)
+            endif
         endif
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -984,10 +987,13 @@ contains
                 output%variables(v)%obs          = 0
                 output%variables(v)%coefficients = 0
             else
-                ! unfortunately coefficients has to be allocated even if it is not used because it is indexed
-                ! however, it does not need a complete time sequence or variable size because they are never indexed
-                allocate(output%variables(v)%coefficients(n_atm_variables+1, 2, nx, ny), stat=Mem_Error)
-                if (Mem_Error /= 0) call memory_error(Mem_Error, "out%variables(v)%coefficients v="//trim(str(v)), [2,2,nx,ny])
+                if (options%logistic_threshold/=kFILL_VALUE) then
+                    allocate(output%variables(v)%coefficients((n_atm_variables+1)*2, 1, nx, ny), stat=Mem_Error)
+                    if (Mem_Error /= 0) call memory_error(Mem_Error, "out%variables(v)%coefficients v="//trim(str(v)), [(n_atm_variables+1)*2,1,nx,ny])
+                else
+                    allocate(output%variables(v)%coefficients(n_atm_variables+1, 1, nx, ny), stat=Mem_Error)
+                    if (Mem_Error /= 0) call memory_error(Mem_Error, "out%variables(v)%coefficients v="//trim(str(v)), [n_atm_variables+1,1,nx,ny])
+                endif
             endif
 
         end do

--- a/src/io/output.f90
+++ b/src/io/output.f90
@@ -74,6 +74,9 @@ contains
                 ! call shift_z_dim(output%variables(i)%coefficients, output_data_4d)
                 ! for now skip the shift and just output as is.
                 call io_write(filename, "coefficients", output%variables(i)%coefficients)
+            else if ((options%write_coefficients).and.(options%pure_regression)) then
+                filename = trim(options%output_file)//trim(output%variables(i)%name)//"_coef.nc"
+                call io_write(filename, "coefficients", output%variables(i)%coefficients)
             endif
 
         enddo

--- a/src/objects/data_structures.f90
+++ b/src/objects/data_structures.f90
@@ -181,6 +181,7 @@ module data_structures
         ! source of data to use for normalization of prediction data
         integer :: normalization_method
     end type atm_config
+
     type, extends(atm_config) :: prediction_config
     end type prediction_config
 
@@ -227,6 +228,13 @@ module data_structures
         ! for pure analog, determine whether to compute the expected value by sampling a random analog (if True),
         ! or to compute the mean across all analogs (if False)
         logical :: sample_analog
+
+        ! store pure regression coefficients in a file for future use.
+        logical :: write_coefficients
+        ! read pure regression coefficients from a file so that no regression is necessary.
+        logical :: read_coefficients
+        ! name of file to read coefficients from.
+        character (len=MAXFILELENGTH) :: coefficients_file
 
         ! if not equal to kFILL_VALUE then it will be used to generate a probability of exceedance
         real    :: logistic_threshold

--- a/src/objects/data_structures.f90
+++ b/src/objects/data_structures.f90
@@ -234,7 +234,7 @@ module data_structures
         ! read pure regression coefficients from a file so that no regression is necessary.
         logical :: read_coefficients
         ! name of file to read coefficients from.
-        character (len=MAXFILELENGTH) :: coefficients_file
+        character (len=MAXFILELENGTH) :: coefficients_files(MAX_NUMBER_VARS)
 
         ! if not equal to kFILL_VALUE then it will be used to generate a probability of exceedance
         real    :: logistic_threshold


### PR DESCRIPTION
This PR allows for the reading and writing of coefficients from the `pure_regression` mode of GARD.

I have tested this with a single precipitation forecast from GEFS and noticed a significant speedup:

```
cpu time
raw: 3s
pure0 (default configuration): 1224s
pure1 (write coefficients): 925s
pure2 (read coefficients): 4s
```

I have also tested that pure0, pure1, and pure2 are all bit-for-bit identical.

xref: https://github.com/NCAR/SHARP/pull/86, https://github.com/lizaclark/ncar_realtime/pull/12

cc @gutmann, @andywood 

closes #32

