### PR TITLE
bug fixes to QM and normalization

### DIFF
--- a/src/downscaling_stats/regression.f90
+++ b/src/downscaling_stats/regression.f90
@@ -1,7 +1,7 @@
 module  regression_mod
 contains
 
-    function compute_regression(x, training_x, training_y, coefficients, error, weights) result(y)
+    function compute_regression(x, training_x, training_y, coefficients, error, weights, used_vars) result(y)
         implicit none
         real,    intent(in),    dimension(:)   :: x
         real,    intent(in),    dimension(:,:) :: training_x
@@ -9,6 +9,7 @@ contains
         real(8), intent(inout), dimension(:)   :: coefficients
         real,    intent(inout),                             optional :: error
         real,    intent(inout), dimension(:),  allocatable, optional :: weights
+        integer, intent(inout), dimension(:),               optional :: used_vars
 
         real,    allocatable,   dimension(:,:) :: training_x_lp
         real,    allocatable,   dimension(:)   :: training_y_lp
@@ -31,10 +32,11 @@ contains
 
         allocate(varlist(nvars))
         varlist = -1
-        useable_vars = 0
-
+        varlist(1) = 1   ! this assumes there is a constant passed in for the first variable... 
+        useable_vars = 1 ! the constant 
+        
         ! find all vars that have some variability through time. 
-        do i=1,nvars
+        do i=2,nvars
             nonzero_count = 0
             do j=1,ntimes
                 if (abs(training_x(j,i)-training_x(1,i))>0) then
@@ -48,6 +50,7 @@ contains
                 varlist(i) = i
             end if
         enddo
+        if (present(used_vars)) used_vars=varlist
 
         ! if there are no useable training variables other than the constant, just return (this should never happen?)
         if (useable_vars <= 1) then

--- a/src/tests/test_qm.f90
+++ b/src/tests/test_qm.f90
@@ -37,6 +37,11 @@ program test_qm
     matching_data = matching_data * 10 + 3
     call test_mapping(input_data, matching_data, "Gain + Offset")
 
+    ! test a negative gain and offset
+    call random_number(matching_data)
+    matching_data = matching_data * -3 - 3
+    call test_mapping(input_data, matching_data, "Negative Values")
+
     ! Then test a fourth root transformation
     call random_number(matching_data)
     matching_data = sqrt(sqrt(matching_data)) * 2 + 3.14159

--- a/src/utilities/quantile_map.f90
+++ b/src/utilities/quantile_map.f90
@@ -70,7 +70,7 @@ contains
         
         ! first handle the bottom of the QM segment
         bottom = 1
-        top = min(EXTREME_WINDOW, int(input_step/4))
+        top = max(1, min(EXTREME_WINDOW, int(input_step/4)))
         qm%start_idx(1) = sum(input_data_sorted( bottom:top )) / (top - bottom + 1)
         
         bottom = top
@@ -78,7 +78,7 @@ contains
         qm%end_idx(1)   = sum(input_data_sorted( bottom:top )) / (top - bottom + 1)
         
         bottom = 1
-        top = min(EXTREME_WINDOW, int(match_step/4))
+        top = max(1, min(EXTREME_WINDOW, int(match_step/4)) )
         qm%offset(1)    = sum(data_to_match_sorted( bottom:top )) / (top - bottom + 1)
         denominator     = qm%end_idx(1) - qm%start_idx(1)
         if (denominator < SMALL_VALUE) then
@@ -115,8 +115,8 @@ contains
             
         end do
         
-        ! For the last segment, make sure it finishes at the final value
-        ! this will not happen otherwise because nseg invariably will not divide nm and ni evenly
+        ! For the last segment, just fit to an average over the top 2-5 values so we can get a more extreme fit
+        ! that isn't dependant just on the absolute highest value. 
         i = nseg
         qm%start_idx(i) = qm%end_idx(i-1)
         bottom          = min(max(int(input_i - input_step/4), ni - EXTREME_WINDOW), ni-1)


### PR DESCRIPTION
Fixed a bug in Quantile mapping related to small quantile segment sizes
Made a few changes so that normalization doesn't have to subtract the minimum value in a dataset anymore.  
Imposed limits on the possible values *after* quantile mapping, so we don't get values that are 100 standard deviations away anymore.  

A few other minor changes to comments elsewhere