### PR TITLE
removed make.log from hdf build to prevent travis timeout

### DIFF
--- a/ci/gard_install_utils
+++ b/ci/gard_install_utils
@@ -36,7 +36,7 @@ function install_hdf5 {
     tar -xzf hdf5-1.10.1.tar.gz
     cd hdf5-1.10.1
     ./configure --prefix=$INSTALLDIR &> config.log
-    make &> make.log
+    make
     make install
     export LIBDIR=${INSTALLDIR}/lib
 }


### PR DESCRIPTION
making HDF5 may take more than 10 minutes which is travis's timeout; it then cancels the build