### PR TITLE
Fixing threshold bug

### DIFF
--- a/src/downscaling_stats/analogs.f90
+++ b/src/downscaling_stats/analogs.f90
@@ -95,60 +95,113 @@ contains
     end subroutine find_analogs
 
     ! compute the mean of input[analogs]
-    module function compute_analog_mean(input, analogs, weights) result(mean)
+    module function compute_analog_mean(input, analogs, mask, weights) result(mean)
         implicit none
         real,    intent(in), dimension(:) :: input
         integer, intent(in), dimension(:) :: analogs
+        real,    intent(in), dimension(:), optional :: mask
         real,    intent(in), dimension(:), optional :: weights
         real                              :: mean
 
-        double precision :: internal_mean ! use double precision internally to avoid errors when summing many numbers
+        double precision :: internal_mean, denom ! use double precision internally to avoid errors when summing many numbers
         integer :: i, n
 
         n = size(analogs)
         internal_mean = 0
 
-        if (present(weights)) then
-            do i = 1, n
-                internal_mean = internal_mean + input( analogs(i) ) * weights(i)
-            enddo
-            mean = internal_mean
-        else
-            do i = 1, n
-                internal_mean = internal_mean + input( analogs(i) )
-            enddo
-            mean = internal_mean / n
-        endif
+        if (present(mask)) then
+            if (present(weights)) then
+                denom = sum(mask(analogs) * weights)
+                if (denom == 0) then
+                    mean = 0
+                    return
+                endif
 
+                do i = 1, n
+                    internal_mean = internal_mean + input( analogs(i) ) * weights(i) * mask(analogs(i))
+                enddo
+                mean = internal_mean / denom
+            else
+                denom = sum(mask(analogs))
+                if (denom == 0) then
+                    mean = 0
+                    return
+                endif
+
+                do i = 1, n
+                    internal_mean = internal_mean + (input(analogs(i)) * mask(analogs(i)))
+                enddo
+                mean = internal_mean / denom
+            endif
+        else
+            if (present(weights)) then
+                do i = 1, n
+                    internal_mean = internal_mean + input( analogs(i) ) * weights(i)
+                enddo
+                mean = internal_mean
+            else
+                do i = 1, n
+                    internal_mean = internal_mean + input( analogs(i) )
+                enddo
+                mean = internal_mean / n
+            endif
+        endif
 
     end function compute_analog_mean
 
     ! compute the root mean square error between input[analogs] and y_hat
-    module function compute_analog_error(input, analogs, y_hat, weights) result(error)
+    module function compute_analog_error(input, analogs, y_hat, mask, weights) result(error)
         implicit none
         real,    intent(in), dimension(:) :: input
         integer, intent(in), dimension(:) :: analogs
         real,    intent(in)               :: y_hat
+        real,    intent(in), dimension(:), optional :: mask
         real,    intent(in), dimension(:), optional :: weights
         real                              :: error
 
-        double precision :: mean
+        double precision :: mean, denom
         integer :: i, n
 
         n = size(analogs)
         mean = 0
+        if (present(mask)) then
+            if (present(weights)) then
+                denom = sum(mask(analogs)*weights)
+                if (denom == 0) then
+                    error = 0
+                    return
+                endif
 
-        if (present(weights)) then
-            do i=1, n
-                mean = mean + (input( analogs(i) ) - y_hat)**2 * weights(i)
-            enddo
-            error = sqrt(mean)
+                do i=1, n
+                    mean = mean + ((input( analogs(i) ) - y_hat)**2) * weights(i) * mask(analogs(i))
+                enddo
+                error = sqrt(mean / denom)
+            else
+                denom = sum(mask(analogs))
+                if (denom == 0) then
+                    error = 0
+                    return
+                endif
+
+                do i=1,n
+                    mean = mean + ((input( analogs(i) ) - y_hat)**2) * mask(analogs(i))
+                enddo
+
+                error = sqrt(mean / denom)
+            endif
         else
-            do i=1,n
-                mean = mean + (input( analogs(i) ) - y_hat)**2
-            enddo
+            if (present(weights)) then
+                do i=1, n
+                    mean = mean + ((input( analogs(i) ) - y_hat)**2) * weights(i)
+                enddo
+                error = sqrt(mean)
+            else
+                do i=1,n
+                    mean = mean + (input( analogs(i) ) - y_hat)**2
+                enddo
 
-            error = sqrt(mean / n)
+                error = sqrt(mean / n)
+            endif
         endif
 
     end function compute_analog_error
@@ -156,7 +209,7 @@ contains
 
     module function compute_analog_exceedance(input, analogs, weights) result(probability)
         implicit none
-        real,    intent(in), dimension(:) :: input ! mask 1 = exceeded, 0 = not exceeded
+        real,    intent(in), dimension(:) :: input ! this is a mask 1 = exceeded, 0 = not exceeded
         integer, intent(in), dimension(:) :: analogs
         real,    intent(in), dimension(:), optional :: weights
         real                              :: probability

--- a/src/downscaling_stats/analogs.f90
+++ b/src/downscaling_stats/analogs.f90
@@ -154,11 +154,10 @@ contains
     end function compute_analog_error
 
 
-    module function compute_analog_exceedance(input, analogs, threshold, weights) result(probability)
+    module function compute_analog_exceedance(input, analogs, weights) result(probability)
         implicit none
-        real,    intent(in), dimension(:) :: input
+        real,    intent(in), dimension(:) :: input ! mask 1 = exceeded, 0 = not exceeded
         integer, intent(in), dimension(:) :: analogs
-        real,    intent(in)               :: threshold
         real,    intent(in), dimension(:), optional :: weights
         real                              :: probability
         integer :: i, n
@@ -173,15 +172,13 @@ contains
             endif
 
             do i = 1, n
-                if (input(analogs(i)) > threshold) then
+                if (input(analogs(i)) > 0) then
                     probability = probability + weights(i)
                 endif
             end do
         else
             do i = 1, n
-                if (input(analogs(i)) > threshold) then
-                    probability = probability + 1
-                endif
+                probability = probability + input(analogs(i))
             end do
 
             probability = probability / n

--- a/src/downscaling_stats/analogs_h.f90
+++ b/src/downscaling_stats/analogs_h.f90
@@ -18,32 +18,33 @@ interface
     end subroutine find_analogs
 
     ! compute the mean of input[analogs]
-    module function compute_analog_mean(input, analogs, weights) result(mean)
+    module function compute_analog_mean(input, analogs, mask, weights) result(mean)
         implicit none
         real,    intent(in), dimension(:) :: input
         integer, intent(in), dimension(:) :: analogs
+        real,    intent(in), dimension(:), optional :: mask
         real,    intent(in), dimension(:), optional :: weights
         real                              :: mean
 
     end function compute_analog_mean
 
     ! compute the root mean square error between input[analogs] and y_hat
-    module function compute_analog_error(input, analogs, y_hat, weights) result(error)
+    module function compute_analog_error(input, analogs, y_hat, mask, weights) result(error)
         implicit none
         real,    intent(in), dimension(:) :: input
         integer, intent(in), dimension(:) :: analogs
         real,    intent(in)               :: y_hat
+        real,    intent(in), dimension(:), optional :: mask
         real,    intent(in), dimension(:), optional :: weights
         real                              :: error
 
     end function compute_analog_error
 
 
-    module function compute_analog_exceedance(input, analogs, threshold, weights) result(probability)
+    module function compute_analog_exceedance(input, analogs, weights) result(probability)
         implicit none
-        real,    intent(in), dimension(:) :: input
+        real,    intent(in), dimension(:) :: input ! this is a mask 1 = exceeded, 0 = not exceeded
         integer, intent(in), dimension(:) :: analogs
-        real,    intent(in)               :: threshold
         real,    intent(in), dimension(:), optional :: weights
         real                              :: probability
 

--- a/src/downscaling_stats/downscaling.f90
+++ b/src/downscaling_stats/downscaling.f90
@@ -306,7 +306,7 @@ contains
                         endif
 
                         call transform_data(options%obs%input_Xforms(v), observed_data, 1, nobs, &
-                                            qm_io=qq_normal, current_threshold)
+                                            qm_io=qq_normal, threshold=current_threshold)
 
                         ! As tempting as it may be, associate statements are not threadsafe!!!
                         output%variables(v)%data(:,i,j) = downscale_point(                                         &
@@ -1070,22 +1070,22 @@ contains
             endif
         else
             if (options%analog_weights) then
-                output = compute_analog_mean(obs, analogs, weights)
+                output = compute_analog_mean(obs, analogs, mask=threshold_mask, weights=weights)
             else
-                output = compute_analog_mean(obs, analogs)
+                output = compute_analog_mean(obs, analogs, mask=threshold_mask)
             endif
 
             if (options%debug) then
                 do j=1,nvars
-                    output_coeff(j) = compute_analog_mean(atm(:, j), analogs)
+                    output_coeff(j) = compute_analog_mean(atm(:, j), analogs, mask=threshold_mask)
                 enddo
             endif
         endif
 
         if (options%analog_weights) then
-            error = compute_analog_error(obs_in, analogs, output, weights)
+            error = compute_analog_error(obs_in, analogs, output, mask=threshold_mask, weights=weights)
         else
-            error = compute_analog_error(obs_in, analogs, output)
+            error = compute_analog_error(obs_in, analogs, output, mask=threshold_mask)
         endif
 
         call System_Clock(timetwo)

--- a/src/downscaling_stats/downscaling.f90
+++ b/src/downscaling_stats/downscaling.f90
@@ -976,7 +976,7 @@ contains
                 endif
 
             else
-                logistic = compute_logistic_regression(x, regression_data, threshold_mask, coefficients)
+                logistic = compute_logistic_regression(x, regression_data, threshold_mask(analogs), coefficients)
 
                 ! Check for severe errors in the logistic regression.  This can happen with some input data.
                 ! If it fails, fall back to the analog exceedence calculation

--- a/src/downscaling_stats/regression.f90
+++ b/src/downscaling_stats/regression.f90
@@ -251,22 +251,13 @@ contains
     end subroutine weighted_least_squares
 
 
-    module function compute_logistic_regression(x, training_x, training_y, coefficients, threshold) result(output)
+    module function compute_logistic_regression(x, training_x, binary_values, coefficients) result(output)
         implicit none
         real,    intent(in) :: x(:)
         real,    intent(in) :: training_x(:,:)
-        real,    intent(in) :: training_y(:)
+        real,    intent(in) :: binary_values(:)
         real(8), intent(out):: coefficients(:)
-        real,    intent(in) :: threshold
         real :: output
-
-        real, dimension(:), allocatable :: binary_values
-        integer :: n
-
-        n = size(training_y)
-        allocate(binary_values(n))
-        binary_values = 0
-        where(training_y > threshold) binary_values = 1
 
         call logistic_regression(training_x, binary_values, coefficients)
 

--- a/src/downscaling_stats/regression_h.f90
+++ b/src/downscaling_stats/regression_h.f90
@@ -20,13 +20,12 @@ interface
         real :: y
     end function compute_regression
 
-    module function compute_logistic_regression(x, training_x, training_y, coefficients, threshold) result(output)
+    module function compute_logistic_regression(x, training_x, binary_values, coefficients) result(output)
         implicit none
         real,    intent(in) :: x(:)
         real,    intent(in) :: training_x(:,:)
-        real,    intent(in) :: training_y(:)
+        real,    intent(in) :: binary_values(:)
         real(8), intent(out):: coefficients(:)
-        real,    intent(in) :: threshold
         real :: output
     end function compute_logistic_regression
 

--- a/src/io/obs_io.f90
+++ b/src/io/obs_io.f90
@@ -80,7 +80,8 @@ contains
                     call create_variable_mask(obs_data%mask, var%data, options%mask_value)
                 endif
 
-                where( var%data > 1e10 ) var%data = 1
+                where( var%data > 1e10 ) var%data = 1e10
+                where( var%data < -1e10 ) var%data = -1e10
                 call compute_grid_stats(var)
                 ! prevent possible divide by 0 in normalization?
                 where( var%stddev == 0 ) var%stddev = 1e-10

--- a/src/utilities/basic_stats.f90
+++ b/src/utilities/basic_stats.f90
@@ -99,8 +99,11 @@ contains
         do y=1,ny
             do x=1,nx
                 difference = input(:,x,y) - mean(x,y)
+
                 ! in case there are bad input data, prevents a floating point overflow
                 where(difference > 1e10) difference = 1e10
+                where(difference < -1e10) difference = -1e10
+
                 stddev(x,y) = sqrt( sum( difference**2 ) / (nt-1) )
             end do
         end do


### PR DESCRIPTION
There was an issue where supplying a logistic threshold was not properly removing data points that did not exceed the threshold at certain points.  Notably, this meant that precipitation predicted by the pure_analog approach was biased very low.  There may still be a related issue to investigate in the pure_regression case, but it should not have as much effect (this will be raised/tracked as a separate issue). 

This code now computes a mask of time steps that do or do not exceed the threshold in the observations at the beginning of processing each grid point, thus any changes to the value (in e.g. normalization or transformation) will not effect the data points used.  